### PR TITLE
Allow self hosted

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ require 'novu'
 client = Novu::Client.new('MY_API_TOKEN')
 ```
 
+If you are using a self-hosted instance of Novu, you can initialize the client with your API token and the URL where your instance is hosted:
+
+```ruby
+require 'novu'
+
+client = Novu::Client.new('MY_API_TOKEN', 'http://your-novu-instance')
+```
+
 You can then call methods on the client to interact with the Novu API:
 
 ```ruby

--- a/lib/novu/client.rb
+++ b/lib/novu/client.rb
@@ -35,14 +35,19 @@ module Novu
     include Novu::Api::Subscribers
     include Novu::Api::Topics
 
-    base_uri "https://api.novu.co/v1"
+    DEFAULT_BASE_URI = "https://api.novu.co/v1"
+
+    base_uri DEFAULT_BASE_URI
     format :json
 
-    def initialize(access_token = nil)
+    def initialize(access_token = nil, base_uri = nil)
       raise ArgumentError, "Api Key cannot be blank or nil" if access_token.blank?
 
       @access_token = access_token.to_s.strip
       self.class.default_options.merge!(headers: { "Authorization" => "ApiKey #{@access_token}" })
+
+      base_uri ||= DEFAULT_BASE_URI
+      self.class.base_uri base_uri
     rescue ArgumentError => e
       puts "Error initializing Novu client: #{e.message}"
     end


### PR DESCRIPTION
Added support to initialize the client with your own self-hosted instance of Novu's URL.